### PR TITLE
Make GTK an optional dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,14 @@ find_package(Freetype REQUIRED)
 find_package(Threads REQUIRED)
 find_package(X11 REQUIRED)
 find_package(ZLIB REQUIRED)
-pkg_search_module(GTK REQUIRED gtk+-3.0)
+pkg_search_module(GTK gtk+-3.0)
 
-set(CURSES_NEED_NCURSES TRUE)
-find_package(Curses REQUIRED)
+set(CURSES_NEED_NCURSES FALSE)
+find_package(Curses)
+
+if(GTK_FOUND)
+   target_compile_definitions(graphics PRIVATE HAVE_GTK)
+endif()
 
 # special case for X11 libs that the FindX11 module doesn't require by default
 if(NOT X11_ICE_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,8 @@ find_package(X11 REQUIRED)
 find_package(ZLIB REQUIRED)
 pkg_search_module(GTK gtk+-3.0)
 
-set(CURSES_NEED_NCURSES FALSE)
+set(CURSES_NEED_NCURSES TRUE)
 find_package(Curses)
-
-if(GTK_FOUND)
-   target_compile_definitions(graphics PRIVATE HAVE_GTK)
-endif()
 
 # special case for X11 libs that the FindX11 module doesn't require by default
 if(NOT X11_ICE_FOUND)
@@ -74,3 +70,8 @@ target_link_libraries(graphics
     ${ZLIB_LIBRARIES}
     ${GTK_LIBRARIES}
 )
+
+if(GTK_FOUND)
+   target_compile_definitions(graphics PRIVATE HAVE_GTK)
+endif()
+

--- a/README.md
+++ b/README.md
@@ -9,10 +9,17 @@ upstream source repo.
 This repo exists to track upstream changes, to provide a build system and to unfuck
 the code a little bit.
 
+Additionally, GTK has been removed as a hard dependancy and Dwarf Fortress will
+run without it. Note that if `[WINDOWED=PROMPT]` in `data/init/init.txt` then
+the game must be run from the terminal so that the user may make their choice
+with an input prompt.
+
 ## Build Dependencies
 
 To build the graphics library you must have the required libraries and
 dev packages installed.
+
+You may ignore any GTK dependency if you do not want to build with support.
 
 ### Arch Linux
 

--- a/g_src/KeybindingScreen.cpp
+++ b/g_src/KeybindingScreen.cpp
@@ -1,7 +1,9 @@
 #ifdef __APPLE__
 # include "osx_messagebox.h"
 #elif defined(unix)
-# include <gtk/gtk.h>
+# ifdef HAVE_GTK
+#  include <gtk/gtk.h>
+# endif
 #endif
 
 #include "GL/glew.h"

--- a/g_src/enabler.cpp
+++ b/g_src/enabler.cpp
@@ -1,7 +1,9 @@
 #ifdef __APPLE__
 # include "osx_messagebox.h"
 #elif defined(unix)
-# include <gtk/gtk.h>
+# ifdef HAVE_GTK
+#  include <gtk/gtk.h>
+# endif
 #endif
 
 #include <cassert>
@@ -717,7 +719,7 @@ int main (int argc, char* argv[]) {
 #ifdef unix
   setlocale(LC_ALL, "");
 #endif
-#if !defined(__APPLE__) && defined(unix)
+#if !defined(__APPLE__) && defined(unix) && defined(HAVE_GTK)
   bool gtk_ok = false;
   if (getenv("DISPLAY"))
     gtk_ok = gtk_init_check(&argc, &argv);
@@ -738,6 +740,7 @@ int main (int argc, char* argv[]) {
   init.begin(); // Load init.txt settings
   
 #if !defined(__APPLE__) && defined(unix)
+ #if defined(HAVE_GTK)
   if (!gtk_ok && !init.display.flag.has_flag(INIT_DISPLAY_FLAG_TEXT)) {
     puts("Display not found and PRINT_MODE not set to TEXT, aborting.");
     exit(EXIT_FAILURE);
@@ -747,6 +750,7 @@ int main (int argc, char* argv[]) {
     puts("Graphical tiles are not compatible with text output, sorry");
     exit(EXIT_FAILURE);
   }
+ #endif
 #endif
 
   // Initialize video, if we /use/ video

--- a/g_src/enabler.cpp
+++ b/g_src/enabler.cpp
@@ -590,6 +590,10 @@ int enablerst::loop(string cmdline) {
 
   // Clean up graphical resources
   delete renderer;
+
+  // FIX infinite loop
+  // https://www.bay12games.com/dwarves/mantisbt/view.php?id=11564
+  return 0;
 }
 
 void enablerst::override_grid_size(int x, int y) {

--- a/g_src/music_and_sound_openal.cpp
+++ b/g_src/music_and_sound_openal.cpp
@@ -250,7 +250,9 @@ void musicsoundst::deinitsound() {
     alDeleteBuffers(1, &buffer);
   }
   // Deinit OpenAL
-  alcMakeContextCurrent(NULL);
+  // FIX infinite loop
+  // https://www.bay12games.com/dwarves/mantisbt/view.php?id=11564
+  //alcMakeContextCurrent(NULL);
   alcDestroyContext(context);
   alcCloseDevice(device);
 
@@ -480,7 +482,10 @@ static bool init_openal() {
 
 void alEnable( ALenum capability ) { _alEnable(capability); }
 void alDisable( ALenum capability ) { _alDisable(capability); }
-ALboolean alIsEnabled( ALenum capability ) { _alIsEnabled(capability); }
+//ALboolean alIsEnabled( ALenum capability ) { _alIsEnabled(capability); }
+// FIX return statement
+// https://www.bay12games.com/dwarves/mantisbt/view.php?id=11564
+ALboolean alIsEnabled( ALenum capability ) { return _alIsEnabled(capability); }
 const ALchar* alGetString( ALenum param ) { return _alGetString(param); }
 void alGetBooleanv( ALenum param, ALboolean* data ) { _alGetBooleanv(param, data); }
 void alGetIntegerv( ALenum param, ALint* data ) { _alGetIntegerv(param, data); }
@@ -490,7 +495,10 @@ ALboolean alGetBoolean( ALenum param ) { return _alGetBoolean(param); }
 ALint alGetInteger( ALenum param ) { return _alGetInteger(param); }
 ALfloat alGetFloat( ALenum param ) { return _alGetFloat(param); }
 ALdouble alGetDouble( ALenum param ) { return _alGetDouble(param); }
-ALenum alGetError( void ) { _alGetError(); }
+//ALenum alGetError( void ) { _alGetError(); }
+// FIX return statement
+// https://www.bay12games.com/dwarves/mantisbt/view.php?id=11564
+ALenum alGetError( void ) { return _alGetError(); }
 ALboolean alIsExtensionPresent( const ALchar* extname ) { return _alIsExtensionPresent(extname); }
 void* alGetProcAddress( const ALchar* fname ) { return _alGetProcAddress(fname); }
 ALenum alGetEnumValue( const ALchar* ename ) { return _alGetEnumValue(ename); }

--- a/g_src/renderer_curses.cpp
+++ b/g_src/renderer_curses.cpp
@@ -1,4 +1,6 @@
+#if defined(__APPLE__) || defined(unix)
 #include <unistd.h>
+#endif
 
 static bool curses_initialized = false;
 

--- a/g_src/renderer_curses.cpp
+++ b/g_src/renderer_curses.cpp
@@ -1,3 +1,5 @@
+#include <unistd.h>
+
 static bool curses_initialized = false;
 
 static void endwin_void() {

--- a/g_src/win32_compat.cpp
+++ b/g_src/win32_compat.cpp
@@ -146,7 +146,7 @@ int MessageBox(HWND *dummy, const char *text, const char *caption, UINT type)
         break;
       }
     }
-  #endif /* HAVE_GTK */
+  #else
     if (isatty(fileno(stdin))) {
       dprintf(2, "Alert %s:\n%s\n", caption ? caption : "", text ? text : "");
       if (type & MB_YESNO) {
@@ -162,6 +162,7 @@ int MessageBox(HWND *dummy, const char *text, const char *caption, UINT type)
       /* just assume windowed if no TTY is available to ask */
       ret = IDNO;
     }
+  #endif /* HAVE_GTK */
   } else {
     // Use curses
     init_curses();

--- a/g_src/win32_compat.cpp
+++ b/g_src/win32_compat.cpp
@@ -146,16 +146,21 @@ int MessageBox(HWND *dummy, const char *text, const char *caption, UINT type)
         break;
       }
     }
-  #endif
-    dprintf(2, "Alert %s:\n%s\n", caption ? caption : "", text ? text : "");
-    if (type & MB_YESNO) {
-      while(ret == IDOK) {
-        dprintf(2, "please answer with 'yes' or 'no'\n");
-        char buf[16];
-        fgets(buf, sizeof buf, stdin);
-        if(!strncmp(buf, "yes", 3)) ret = IDYES;
-        else if(!strncmp(buf, "no", 2)) ret = IDNO;
+  #endif /* HAVE_GTK */
+    if (isatty(fileno(stdin))) {
+      dprintf(2, "Alert %s:\n%s\n", caption ? caption : "", text ? text : "");
+      if (type & MB_YESNO) {
+        while(ret == IDOK) {
+          dprintf(2, "please answer with 'yes' or 'no'\n");
+          char buf[16];
+          fgets(buf, sizeof buf, stdin);
+          if(!strncmp(buf, "yes", 3)) ret = IDYES;
+          else if(!strncmp(buf, "no", 2)) ret = IDNO;
+        }
       }
+    } else {
+      /* just assume windowed if no TTY is available to ask */
+      ret = IDNO;
     }
   } else {
     // Use curses
@@ -163,7 +168,7 @@ int MessageBox(HWND *dummy, const char *text, const char *caption, UINT type)
     erase();
     gps.force_full_display_count = 1;
     wattrset(*stdscr_p, A_NORMAL | COLOR_PAIR(1));
-    
+
     mvwaddstr(*stdscr_p, 0, 5, caption);
     mvwaddstr(*stdscr_p, 2, 2, text);
     nodelay(*stdscr_p, false);

--- a/g_src/win32_compat.cpp
+++ b/g_src/win32_compat.cpp
@@ -13,7 +13,11 @@
 # ifdef __APPLE__
 #  include "osx_messagebox.h"
 # elif defined(unix)
-#  include <gtk/gtk.h>
+#  ifdef HAVE_GTK
+#    include <gtk/gtk.h>
+#  else
+#    include <unistd.h>
+#  endif
 # endif
 #endif
 
@@ -112,6 +116,7 @@ int MessageBox(HWND *dummy, const char *text, const char *caption, UINT type)
   }
 # else // GTK code
   if (getenv("DISPLAY")) {
+  #ifdef HAVE_GTK
     // Have X, will dialog
     GtkWidget *dialog = gtk_message_dialog_new(NULL,
                                                GTK_DIALOG_DESTROY_WITH_PARENT,
@@ -139,6 +144,17 @@ int MessageBox(HWND *dummy, const char *text, const char *caption, UINT type)
       case GTK_RESPONSE_YES:
         ret = IDYES;
         break;
+      }
+    }
+  #endif
+    dprintf(2, "Alert %s:\n%s\n", caption ? caption : "", text ? text : "");
+    if (type & MB_YESNO) {
+      while(ret == IDOK) {
+        dprintf(2, "please answer with 'yes' or 'no'\n");
+        char buf[16];
+        fgets(buf, sizeof buf, stdin);
+        if(!strncmp(buf, "yes", 3)) ret = IDYES;
+        else if(!strncmp(buf, "no", 2)) ret = IDNO;
       }
     }
   } else {
@@ -173,7 +189,7 @@ int MessageBox(HWND *dummy, const char *text, const char *caption, UINT type)
     }
     nodelay(*stdscr_p, -1);
   }
-# endif
+  #endif
   
   if (toggle_screen) {
     enabler.toggle_fullscreen();


### PR DESCRIPTION
I thought I might as well make a PR for this given I've been running it since February without issue:

I run Gentoo without GTK and compiling it to run DF was a pain so I took direct inspiration from [rofl0r's repo](https://github.com/rofl0r/df-libgraphics), which mind you, hasn't been updated in years, and made GTK optional, replacing it with terminal input instead if it isn't present on build.

Included in the PR is also a bugfix from [here](https://www.bay12games.com/dwarves/mantisbt/view.php?id=11564) which fixes a few functions that weren't returning anything and causing crashes on Gentoo (and quite possibly other systems).