### PR TITLE
Use the GLEW::glew CMake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ target_link_libraries(graphics
     ${SDL_IMAGE_LIBRARIES}
     ${OPENAL_LIBRARY}
     ${GTK2_LIBRARIES}
-    ${GLEW_LIBRARIES}
+    GLEW::glew
     ${FREETYPE_LIBRARIES}
     ${X11_LIBRARIES}
     ${CURSES_LIBRARIES}


### PR DESCRIPTION
GLEW_LIBRARIES is not set in recent versions of cmake, causing the build to fail.

I honestly have no idea how any of this works but people seem to be suggesting using GLEW::glew instead and that works.

- https://discourse.cmake.org/t/the-findglew-cmake-module-does-not-set-glew-libraries-in-some-cases/989
- https://stackoverflow.com/a/75401305